### PR TITLE
Feat: Page - MyPage - 주문 내역 상세 컴포넌트 구현

### DIFF
--- a/src/features/seller/manage_orders/api/sellerOrdersApi.ts
+++ b/src/features/seller/manage_orders/api/sellerOrdersApi.ts
@@ -3,6 +3,7 @@ import { apiClient } from '@/lib/apiClient'
 import { SellerOrderSearchParams, SellerOrderSearchResponse, OrderStatusCounts } from '../types/seller-order.types'
 import { ApiResponse } from '@/types/api'
 import { getMockSellerOrdersResponse, MOCK_ORDER_STATUS_COUNTS } from '@/mocks/SellerOrders'
+import { OrderStatus } from '@/features/orders'
 
 export const sellerOrdersApi = {
   /**
@@ -48,4 +49,21 @@ export const sellerOrdersApi = {
     // )
     // return response.data!
   },
+
+  /**
+   * 주문 상태 변경
+   * @param orderId 주문 ID
+   * @param newStatus 새로운 주문 상태
+   */
+  updateOrderStatus: async (
+    orderId: number,
+    newStatus: OrderStatus
+  ): Promise<void> => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    // ✅ 백엔드 준비되면 아래 주석 해제
+    // await apiClient.patch<ApiResponse<void>>(
+    //   `/seller/orders/${orderId}/status`,
+    //   { status: newStatus }
+    // )
+  }
 }

--- a/src/features/seller/manage_orders/components/OrderDetailModal.tsx
+++ b/src/features/seller/manage_orders/components/OrderDetailModal.tsx
@@ -1,0 +1,237 @@
+// src/features/seller/manage_orders/components/OrderDetailModal.tsx
+import { useState } from 'react'
+import { OrderDetail, OrderStatus } from '@/features/orders'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Separator } from '@/components/ui/separator'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import Image from 'next/image'
+import { STATUS_KR } from '@/features/seller/constants/seller-constants'
+import { toast } from 'sonner'
+import { sellerOrdersApi } from '../api/sellerOrdersApi'
+
+type OrderDetailModalProps = {
+  order: OrderDetail | null
+  isOpen: boolean
+  onClose: () => void
+  onStatusUpdate?: () => void
+}
+
+export function OrderDetailModal({
+                                   order,
+                                   isOpen,
+                                   onClose,
+                                   onStatusUpdate,
+                                 }: OrderDetailModalProps) {
+  const [selectedStatus, setSelectedStatus] = useState<OrderStatus | null>(null)
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false)
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  if (!order) return null
+
+  const handleStatusChange = (newStatus: OrderStatus) => {
+    setSelectedStatus(newStatus)
+    setShowConfirmDialog(true)
+  }
+
+  const handleConfirmStatusChange = async () => {
+    if (!selectedStatus) return
+
+    setIsUpdating(true)
+    try {
+      // 주문 상태 업데이트 API 호출
+      await sellerOrdersApi.updateOrderStatus(order.orderId, selectedStatus)
+
+      toast.success('주문 상태가 변경되었습니다.', {
+        position: 'top-center'
+      })
+      setShowConfirmDialog(false)
+      onStatusUpdate?.()
+      onClose()
+    } catch (error) {
+      toast.error('상태 변경에 실패했습니다.')
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={isOpen} onOpenChange={onClose}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>주문 상세 정보</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-6">
+            {/* 주문 기본 정보 */}
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <p className="text-sm font-semibold text-gray-400">
+                    {order.orderDate}
+                  </p>
+                  <p className="font-bold">주문번호 {order.orderNumber}</p>
+                </div>
+                {/* 상태 변경 드롭다운 */}
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">주문 상태:</span>
+                  <Select
+                    value={order.orderStatus}
+                    onValueChange={(value) =>
+                      handleStatusChange(value as OrderStatus)
+                    }
+                  >
+                    <SelectTrigger className="w-[140px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="PENDING">
+                        {STATUS_KR.PENDING}
+                      </SelectItem>
+                      <SelectItem value="DELIVERING">
+                        {STATUS_KR.DELIVERING}
+                      </SelectItem>
+                      <SelectItem value="DELIVERED">
+                        {STATUS_KR.DELIVERED}
+                      </SelectItem>
+                      <SelectItem value="CANCEL">{STATUS_KR.CANCEL}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <Separator className="border-black" />
+            </div>
+
+            {/* 주문 상품 목록 */}
+            <div>
+              <p className="mb-3 text-lg font-bold">주문 상품</p>
+              <div className="space-y-3">
+                {order.items.map((item) => (
+                  <div
+                    key={item.itemId}
+                    className="flex justify-between items-center p-3 bg-gray-50 rounded-lg"
+                  >
+                    <div className="flex gap-3">
+                      <Image
+                        className="rounded-md"
+                        width={56}
+                        height={72}
+                        src={item.thumbnailUrl}
+                        alt={item.name}
+                      />
+                      <div className="flex flex-col justify-between text-sm">
+                        <p className="font-semibold text-gray-400">샛별배송</p>
+                        <p className="font-medium">{item.name}</p>
+                        <p className="text-gray-600">
+                          {item.purchasePrice.toLocaleString()}원 × {item.quantity}개
+                        </p>
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-bold">
+                        {(item.purchasePrice * item.quantity).toLocaleString()}원
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* 주문 정보 요약 */}
+            <div>
+              <p className="mb-3 text-lg font-bold">주문 정보</p>
+              <div className="space-y-2 bg-gray-50 rounded-lg p-4">
+                <OrderInfoRow
+                  label="주문번호"
+                  value={order.orderNumber}
+                  primary
+                />
+                <OrderInfoRow label="주문일시" value={order.orderDate} />
+                <OrderInfoRow
+                  label="총 수량"
+                  value={`${order.items.reduce((sum, item) => sum + item.quantity, 0)}개`}
+                />
+                <OrderInfoRow
+                  label="총 금액"
+                  value={`${order.totalPrice.toLocaleString()}원`}
+                  primary
+                />
+                <OrderInfoRow label="주문자" value={order.deliveryInfo.recipientName}/>
+                <OrderInfoRow label="연락처" value={order.deliveryInfo.recipientPhone}/>
+                <OrderInfoRow label="배송지" value={`${order.deliveryInfo.address} ${order.deliveryInfo.addressDetail}`}/>
+                <OrderInfoRow label="배송 요청 사항" value={order.deliveryRequest ? order.deliveryRequest : ""}/>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* 상태 변경 확인 다이얼로그 */}
+      <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>주문 상태 변경 확인</AlertDialogTitle>
+            <AlertDialogDescription>
+              주문 상태를{' '}
+              <span className="font-bold text-black">
+                {STATUS_KR[order.orderStatus]}
+              </span>
+              에서{' '}
+              <span className="font-bold text-black">
+                {selectedStatus && STATUS_KR[selectedStatus]}
+              </span>
+              (으)로 변경하시겠습니까?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isUpdating}>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmStatusChange}
+              disabled={isUpdating}
+              className="bg-deepBlue hover:bg-deepBlue/90"
+            >
+              {isUpdating ? '변경 중...' : '변경'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+// 주문 정보 행 컴포넌트
+type OrderInfoRowProps = {
+  label: string
+  value: string
+  primary?: boolean
+}
+
+function OrderInfoRow({ label, value, primary }: OrderInfoRowProps) {
+  return (
+    <div className="flex justify-between items-center">
+      <span className="text-sm text-gray-600">{label}</span>
+      <span className={`text-sm ${primary ? 'font-bold' : ''}`}>{value}</span>
+    </div>
+  )
+}

--- a/src/features/seller/manage_orders/components/SellerOrderTable.tsx
+++ b/src/features/seller/manage_orders/components/SellerOrderTable.tsx
@@ -1,4 +1,4 @@
-import { Order } from '@/features/orders'
+import { OrderDetail } from '@/features/orders'
 import {
   Table,
   TableBody,
@@ -7,19 +7,42 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { Badge } from 'lucide-react'
 import {
   STATUS_COLORS,
   STATUS_KR,
 } from '@/features/seller/constants/seller-constants'
 import { Button } from '@/components/ui/button'
+import { useState } from 'react'
+import { OrderDetailModal } from '@/features/seller/manage_orders/components/OrderDetailModal'
 
 type SellerOrderTableProps = {
-  orders: Order[]
+  orders: OrderDetail[]
   isLoading?: boolean
+  onRefresh?: () => void
 }
 
-export function SellerOrderTable({ orders, isLoading }: SellerOrderTableProps) {
+export function SellerOrderTable({
+  orders,
+  isLoading,
+  onRefresh,
+}: SellerOrderTableProps) {
+  const [selectedOrder, setSelectedOrder] = useState<OrderDetail | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const handleViewDetail = (order: OrderDetail) => {
+    setSelectedOrder(order)
+    setIsModalOpen(true)
+  }
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false)
+    setSelectedOrder(null)
+  }
+
+  const handleStatusUpdate = () => {
+    onRefresh?.()
+  }
+
   if (isLoading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -37,54 +60,67 @@ export function SellerOrderTable({ orders, isLoading }: SellerOrderTableProps) {
   }
 
   return (
-    <div className="rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="text-center">주문번호</TableHead>
-            <TableHead className="text-center">상품명</TableHead>
-            <TableHead>수량</TableHead>
-            <TableHead className="text-center">금액</TableHead>
-            <TableHead className="text-center">상태</TableHead>
-            <TableHead className="text-center">주문일</TableHead>
-            <TableHead>상세조회</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {orders.map((order) => (
-            <TableRow key={order.orderId}>
-              <TableCell className="font-medium">{order.orderNumber}</TableCell>
-              <TableCell>
-                <div className="space-y-1">
-                  {order.items[0].name}
-                  {order.items.length > 1 && (
-                    <span className="ml-1 text-muted-foreground">
-                      외 {order.items.length - 1}건
-                    </span>
-                  )}
-                </div>
-              </TableCell>
-              <TableCell>
-                {order.items.reduce((sum, item) => sum + item.quantity, 0)}개
-              </TableCell>
-              <TableCell>{order.totalPrice.toLocaleString()}원</TableCell>
-              <TableCell>
-                <p
-                  className={`${STATUS_COLORS[order.orderStatus]} rounded-lg py-1 text-center`}
-                >
-                  {STATUS_KR[order.orderStatus]}
-                </p>
-              </TableCell>
-              <TableCell>
-                {new Date(order.orderDate).toLocaleDateString('ko-KR')}
-              </TableCell>
-              <TableCell>
-                <Button className="bg-deepBlue hover:bg-deepBlue">조회</Button>
-              </TableCell>
+    <>
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="text-center">주문번호</TableHead>
+              <TableHead className="text-center">상품명</TableHead>
+              <TableHead>수량</TableHead>
+              <TableHead className="text-center">금액</TableHead>
+              <TableHead className="text-center">상태</TableHead>
+              <TableHead className="text-center">주문일</TableHead>
+              <TableHead>상세조회</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+          </TableHeader>
+          <TableBody>
+            {orders.map((order) => (
+              <TableRow key={order.orderId}>
+                <TableCell className="font-medium">
+                  {order.orderNumber}
+                </TableCell>
+                <TableCell>
+                  <div className="space-y-1">
+                    {order.items[0].name}
+                    {order.items.length > 1 && (
+                      <span className="ml-1 text-muted-foreground">
+                        외 {order.items.length - 1}건
+                      </span>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  {order.items.reduce((sum, item) => sum + item.quantity, 0)}개
+                </TableCell>
+                <TableCell>{order.totalPrice.toLocaleString()}원</TableCell>
+                <TableCell>
+                  <p
+                    className={`${STATUS_COLORS[order.orderStatus]} rounded-lg py-1 text-center`}
+                  >
+                    {STATUS_KR[order.orderStatus]}
+                  </p>
+                </TableCell>
+                <TableCell>
+                  {new Date(order.orderDate).toLocaleDateString('ko-KR')}
+                </TableCell>
+                <TableCell>
+                  <Button className="bg-deepBlue hover:bg-deepBlue/90"
+                  onClick={() => handleViewDetail(order)}>
+                    조회
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <OrderDetailModal
+        order={selectedOrder}
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        onStatusUpdate={handleStatusUpdate}
+      />
+    </>
   )
 }

--- a/src/features/seller/manage_orders/types/seller-order.types.ts
+++ b/src/features/seller/manage_orders/types/seller-order.types.ts
@@ -1,6 +1,6 @@
 // src/features/orders/types/seller-order.types.ts
 import { PaginationDto } from '@/types/common'
-import { Order, OrderStatus } from '@/features/orders'
+import { OrderDetail, OrderStatus } from '@/features/orders'
 
 /**
  * 판매자 주문 검색 파라미터
@@ -20,7 +20,7 @@ export interface SellerOrderSearchParams {
  * ✅ 백엔드 ItemSearchResponseDto와 유사한 구조
  */
 export interface SellerOrderSearchResponse {
-  orders: Order[]
+  orders: OrderDetail[]
   pagination: PaginationDto
 }
 

--- a/src/mocks/SellerOrders.ts
+++ b/src/mocks/SellerOrders.ts
@@ -1,12 +1,12 @@
 // src/mocks/sellerOrders.ts
-import { Order } from '@/features/orders/types/order'
+import { OrderDetail } from '@/features/orders/types/order'
 import { SellerOrderSearchResponse, OrderStatusCounts } from '@/features/seller/manage_orders/types/seller-order.types'
 
 
 /**
  * 판매자 주문 목록 목 데이터
  */
-export const MOCK_SELLER_ORDERS: Order[] = [
+export const MOCK_SELLER_ORDERS: OrderDetail[] = [
   {
     orderId: 1,
     orderNumber: 'ORD-2024-001',
@@ -29,6 +29,13 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '김철수',
+      recipientPhone: '010-1234-5678',
+      address: '서울시 강남구 테헤란로 123',
+      addressDetail: '456호',
+    },
+    deliveryRequest: '부재 시 문 앞에 놓아주세요',
   },
   {
     orderId: 2,
@@ -45,6 +52,13 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '이영희',
+      recipientPhone: '010-2345-6789',
+      address: '서울시 송파구 올림픽로 234',
+      addressDetail: '101동 1502호',
+    },
+    deliveryRequest: '경비실에 맡겨주세요',
   },
   {
     orderId: 3,
@@ -68,6 +82,12 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '박민수',
+      recipientPhone: '010-3456-7890',
+      address: '경기도 성남시 분당구 판교로 345',
+      addressDetail: '202호',
+    },
   },
   {
     orderId: 4,
@@ -84,6 +104,13 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '최지은',
+      recipientPhone: '010-4567-8901',
+      address: '서울시 마포구 월드컵북로 456',
+      addressDetail: '3층',
+    },
+    deliveryRequest: '직접 받겠습니다',
   },
   {
     orderId: 5,
@@ -107,6 +134,12 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '정수연',
+      recipientPhone: '010-5678-9012',
+      address: '인천시 연수구 송도과학로 567',
+      addressDetail: '1204호',
+    },
   },
   {
     orderId: 6,
@@ -130,6 +163,13 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '강태희',
+      recipientPhone: '010-6789-0123',
+      address: '부산시 해운대구 해운대로 678',
+      addressDetail: '201동 803호',
+    },
+    deliveryRequest: '배송 전 연락 부탁드립니다',
   },
   {
     orderId: 7,
@@ -146,6 +186,12 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '윤서준',
+      recipientPhone: '010-7890-1234',
+      address: '대전시 유성구 대학로 789',
+      addressDetail: '빌라 2층',
+    },
   },
   {
     orderId: 8,
@@ -169,6 +215,13 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '한지민',
+      recipientPhone: '010-8901-2345',
+      address: '광주시 북구 첨단과기로 890',
+      addressDetail: '105동 602호',
+    },
+    deliveryRequest: '새벽 배송 부탁드립니다',
   },
   {
     orderId: 9,
@@ -199,6 +252,12 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '임하늘',
+      recipientPhone: '010-9012-3456',
+      address: '울산시 남구 삼산로 901',
+      addressDetail: '103호',
+    },
   },
   {
     orderId: 10,
@@ -215,12 +274,19 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '송민호',
+      recipientPhone: '010-0123-4567',
+      address: '제주시 첨단로 1012',
+      addressDetail: '단독주택',
+    },
+    deliveryRequest: '조심히 다뤄주세요',
   },
   {
     orderId: 11,
     orderNumber: 'ORD-2024-011',
     orderDate: '2024-11-15',
-    orderStatus: 'PENDING',
+    orderStatus: 'CANCEL',
     totalPrice: 45000,
     items: [
       {
@@ -238,6 +304,13 @@ export const MOCK_SELLER_ORDERS: Order[] = [
         thumbnailUrl: 'https://via.placeholder.com/100',
       },
     ],
+    deliveryInfo: {
+      recipientName: '오세훈',
+      recipientPhone: '010-1122-3344',
+      address: '세종시 한누리대로 1113',
+      addressDetail: '304호',
+    },
+    deliveryRequest: '고객 변심으로 취소',
   },
 ]
 

--- a/src/pages/mypage/seller/manage-orders.tsx
+++ b/src/pages/mypage/seller/manage-orders.tsx
@@ -18,13 +18,14 @@ export default function ManageOrders() {
   const {
     data: orderData,
     isLoading: isLoadingOrders,
-    error: ordersError
+    error: ordersError,
+    refetch: refetchOrders,
   } = useSellerOrders({
     ...filters,
     page: currentPage,
     perPage: 10,
   })
-  const {data: statusCounts} = useOrderStatusCounts()
+  const {data: statusCounts, refetch: refetchCounts} = useOrderStatusCounts()
   useErrorHandler(ordersError)
 
   const handleSearch = (newFilters: Omit<SellerOrderSearchParams, 'page'| 'perPage'>)=> {
@@ -34,6 +35,12 @@ export default function ManageOrders() {
 
   const handlePageChange = (page: number)=> {
     setCurrentPage(page)
+  }
+
+  const handleRefresh = () => {
+    // 주문 목록과 상태 카운트 모두 새로고침
+    refetchOrders()
+    refetchCounts()
   }
 
   return (
@@ -78,7 +85,7 @@ export default function ManageOrders() {
           <SellerOrderFilter onSearch={handleSearch} />
 
           {/* 테이블 */}
-          <SellerOrderTable orders={orderData?.orders ?? []} isLoading={isLoadingOrders} />
+          <SellerOrderTable orders={orderData?.orders ?? []} isLoading={isLoadingOrders} onRefresh={handleRefresh}/>
 
           {/* 페이지네이션 */}
           {orderData?.pagination && (


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #21 #24 
- close : #24 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 주문 내역 상세 모달 컴포넌트, 상태 수정 기능 구현
- 목 데이터 활용 중이기 때문에 백엔드 api 완료 후 테스트 필요

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->
1. 주문 내역 페이지
<img width="1162" height="1137" alt="image" src="https://github.com/user-attachments/assets/d0e7eb43-dfb8-49a5-8e0a-81c47836b8fd" />
2. 주문 내역 상세 모달
<img width="1200" height="1094" alt="image" src="https://github.com/user-attachments/assets/8ca8b0d8-a387-48c7-bb59-dbd5cd544c46" />

3. 주문 상태 변경
<img width="1456" height="1102" alt="image" src="https://github.com/user-attachments/assets/4f0855d3-a5d9-4935-bc8a-4d6671b877d1" />

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
