### PR TITLE
Feat: Page - 페이지 - 결제 완료 페이지 구현

### DIFF
--- a/src/features/cart/types/cart.ts
+++ b/src/features/cart/types/cart.ts
@@ -1,7 +1,6 @@
 import { DeliveryType } from '@/features/item/types/item'
 
 /**
-import { DeliveryType } from '@/features/item/types/item';
  * 장바구니 아이템
  */
 export interface CartItem {
@@ -16,9 +15,10 @@ export interface CartItem {
 }
 
 export interface CartResponse {
-  cartItems: CartItem[]
+  cartId: number
   totalPrice: number
   totalCount: number // 헤더 장바구니 최종 갯수 표시하기 위함
+  cartItems: CartItem[]
 }
 /**
  * 장바구니 추가 요청

--- a/src/features/orders/api/queryKeys.ts
+++ b/src/features/orders/api/queryKeys.ts
@@ -6,7 +6,5 @@ export const orderKeys = {
   list: (period: OrderPeriod, search: string) =>
     [...orderKeys.lists(), { period, search }] as const,
   details: () => [...orderKeys.all, 'detail'] as const,
-  // detail: (id: number) => [...orderKeys.details(), id] as const,
-  detail: (orderNumber: string | number) =>
-    [...orderKeys.all, 'detail', String(orderNumber)] as const,
+  detail: (id: number) => [...orderKeys.details(), id] as const,
 }

--- a/src/features/orders/components/OrderComplete.tsx
+++ b/src/features/orders/components/OrderComplete.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { useRouter } from 'next/router'
+import { Check } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { OrderCreateResponse } from '../types/order'
+
+interface OrderCompleteProps {
+  orderData: OrderCreateResponse
+}
+
+export default function OrderComplete({ orderData }: OrderCompleteProps) {
+  const router = useRouter()
+
+  return (
+    <div className="flex w-[400px] flex-col justify-center rounded-xl bg-gray-100 p-6 font-sans text-[#333]">
+      <div className="mb-8 mt-8 flex flex-col items-center gap-2">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-softBlue">
+          <Check className="h-6 w-6 text-deepBlue" strokeWidth={3} />
+        </div>
+        <h2 className="text-[24px] font-bold text-deepBlue">
+          주문을 완료했어요
+        </h2>
+      </div>
+
+      <div className="w-full max-w-[400px] space-y-4">
+        <div className="rounded-xl bg-white p-5">
+          <div className="mb-4">
+            <p className="mb-1 font-medium leading-relaxed text-[#333]">
+              {orderData.address} {orderData.addressDetail}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-[#999]">
+            <span>주문번호 {orderData.orderNumber}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between rounded-xl bg-white p-5">
+          <span className="font-bold text-[#333]">주문 금액</span>
+          <span className="text-[20px] font-bold text-[#333]">
+            {orderData.totalPrice.toLocaleString()}원
+          </span>
+        </div>
+
+        <div className="py-2 text-[12px] leading-5 text-[#999]">
+          <ul className="list-disc space-y-1 pl-4">
+            <li>배송완료 알림 메시지는 샛별배송 상품에 한해서만 발송됩니다.</li>
+            <li>
+              [주문완료], [배송준비중] 상태일 경우에만 주문내역 상세페이지에서
+              주문 취소가 가능합니다.
+            </li>
+            <li>
+              엘리베이터 이용이 어려운 경우 6층 이상부터는 공동 현관 앞 또는
+              경비실로 대응 배송 될 수 있습니다.
+            </li>
+            <li>
+              실제 출입 정보가 다를 경우, 부득이하게 1층 공동현관 앞 또는 경비실
+              앞에 배송될 수 있습니다.
+            </li>
+            <li>
+              주문 / 배송 및 기타 문의가 있을 경우, 1:1 문의에 남겨주시면 신속히
+              해결해드리겠습니다.
+            </li>
+          </ul>
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3">
+          <Button
+            variant="outline"
+            className="h-[52px] w-full border-[#ddd] text-[16px] font-medium text-[#333] hover:bg-gray-50"
+            onClick={() => router.push(`/mypage/orders/${orderData.orderId}`)}
+          >
+            주문 상세보기
+          </Button>
+
+          <Button
+            className="h-[52px] w-full bg-deepBlue text-[16px] font-medium text-white hover:bg-deepBlue/80"
+            onClick={() => router.push('/')}
+          >
+            쇼핑 계속하기
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/orders/types/order.ts
+++ b/src/features/orders/types/order.ts
@@ -84,8 +84,8 @@ export interface OrderCreateRequest {
 }
 
 export interface OrderItemInfo {
-  cartItemId: number // ✅ 장바구니 항목 ID (명확하게 구분)
-  itemId: number // ✅ 실제 상품 ID
+  cartItemId: number
+  itemId: number
   price: number
   quantity: number
 }
@@ -93,6 +93,7 @@ export interface OrderItemInfo {
 // 주문 생성 API 응답
 // 최종 결제 페이지에 보여줘야 함
 export interface OrderCreateResponse {
+  orderId: number
   orderNumber: string
   address: string
   addressDetail: string

--- a/src/pages/cart/index.tsx
+++ b/src/pages/cart/index.tsx
@@ -20,7 +20,10 @@ export default function CartPage() {
   const router = useRouter()
 
   const { data, isLoading } = useCart()
-  const cartItems = data?.cartItems || []
+
+  const cartItems = useMemo(() => {
+    return data?.cartItems || []
+  }, [data])
 
   const { mutate: updateQuantity } = useUpdateCartQuantity()
   const { mutate: removeItem } = useRemoveCartItem()


### PR DESCRIPTION
결제 완료를 컴포넌트로 빼내어 주문완료 페이지에 구현

Resolves: #12, #20
Ref : #12

## #️⃣ 연관된 이슈
- #12 
- close : #12 #20 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 결제 완료 페이지를 컴포넌트로 빼내어 결제 페이지에 응답 if 문으로 처리하여 구성하였습니다.
- cartId추가하여 order/index.tsx에 cartId 0으로 두었던거 해결했습니다.

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->
<img width="571" height="657" alt="스크린샷 2025-11-23 오전 1 09 14" src="https://github.com/user-attachments/assets/95ee0add-1142-4ed4-a0fa-40865b0c2f84" />


## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
cartId 가 없다면 , 0으로 설정해두었는데 더 좋은 방안이 있을까요?
