### PR TITLE
Fix: Page - 탭 이름 고정

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,13 +4,17 @@ import Layout from '@/components/layout/Layout'
 import { Toaster } from 'sonner'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from '@/lib/queryClient'
+import Head from 'next/head'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
+      <Head>
+        <title>EzShop</title>
+      </Head>
       <QueryClientProvider client={queryClient}>
         <Layout>
-          <Toaster/>
+          <Toaster />
           <Component {...pageProps} />
         </Layout>
       </QueryClientProvider>


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 페이지 이동시 탭 이름 변경되는 것을  EzShop으로 고정

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
