### PR TITLE
Fix: 카테고리 목록이 한글로 표시되도록 수정

### DIFF
--- a/src/components/common/HomeCategory.tsx
+++ b/src/components/common/HomeCategory.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Link from 'next/link'
 import { useState } from 'react'
 import {
@@ -23,6 +21,7 @@ import {
   type CarouselApi,
 } from '@/components/ui/carousel'
 import { useCategories } from '@/features/category/hooks/useCategories'
+import { CATEGORY_NAME_KR } from '@/features/category/constants/category-constants'
 
 // 왼쪽이 categoryName, 오른쪽이 lucide icon 명칭
 const CATEGORY_ICONS: Record<string, any> = {
@@ -100,7 +99,7 @@ export default function HomeCategory() {
                           <IconWrapper Icon={IconComponent} />
                         </div>
                         <span className="relative mt-2 text-[14px] text-gray-700 group-hover:text-mainBlue">
-                          {category}
+                          {CATEGORY_NAME_KR[category] || category}
                           <span className="absolute bottom-0 left-0 h-[1.5px] w-0 bg-mainBlue transition-all duration-300 group-hover:w-full"></span>
                         </span>
                       </Link>

--- a/src/features/category/constants/category-constants.ts
+++ b/src/features/category/constants/category-constants.ts
@@ -1,0 +1,12 @@
+export const CATEGORY_NAME_KR: Record<string, string> = {
+  vegetable: '채소',
+  fruit: '과일',
+  seafood: '해산물',
+  meat: '정육',
+  mealkit: '밀키트',
+  drinks: '음료·생수',
+  snacks: '간식·과자',
+  bakery: '베이커리',
+  dairy: '우유·유제품',
+  alcohol: '주류',
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #72 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## ✅ 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 카테고리 영문-한글 매핑 상수(CATEGORY_NAME_KR) 추가
- HomeCategory 컴포넌트 UI에 한글 명칭 적용

## 📸 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 🗨️ 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
